### PR TITLE
feat: tweaks for production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,6 +3090,7 @@ dependencies = [
  "reqwest 0.12.20",
  "serde",
  "serde_json",
+ "solana-account-decoder-client-types",
  "solana-client",
  "solana-commitment-config",
  "solana-metrics",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pye-cli transfer-excess-rewards \
 There are several ways to read the metrics logged. For instance, we can use the InfluxDB CLI:
 
 1. Get container id using `docker ps`, e.g. `pye-program-library-influxdb-1`
-2. Connect to InfluxDB container with `docker exec -it pye-program-library-influxdb-1 influx`.
+2. Connect to InfluxDB container with `docker exec -it bonds-cli-influxdb-1 influx`.
 3. Run the following
 
 ```

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anchor-lang = { workspace = true }
 anchor-client = { workspace = true, default-features = false, features = ["async"] }
 borsh = "1.3"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 dialoguer = "0.11"
 pye-core-cpi = { workspace = true }
 solana-client = "2.2.7"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,6 +10,7 @@ borsh = "1.3"
 clap = { version = "4", features = ["derive", "env"] }
 dialoguer = "0.11"
 pye-core-cpi = { workspace = true }
+solana-account-decoder-client-types = "2.2.7"
 solana-client = "2.2.7"
 solana-commitment-config = "2.2.1"
 solana-sdk = { version = "2.2.2", features = ["borsh"] }

--- a/cli/src/commands/transfer_excess_rewards.rs
+++ b/cli/src/commands/transfer_excess_rewards.rs
@@ -4,7 +4,7 @@ use crate::metrics_helpers::*;
 use crate::rewards::block_rewards::calculate_excess_block_reward;
 use crate::rewards::inflation_rewards::calculate_excess_inflation_reward;
 use crate::rewards::mev_rewards::{calculate_excess_mev_reward, fetch_and_filter_mev_data};
-use crate::transactions::transfer_excess_rewards_with_delegate_tips;
+use crate::transactions::transfer_excess_rewards;
 use anchor_client::Cluster;
 use anyhow::{anyhow, Result};
 use dialoguer::Confirm;
@@ -118,7 +118,7 @@ pub async fn handle_transfer_excess_rewards(args: TransferExcessRewardsArgs) -> 
         .interact()?
     {
         let cluster = Cluster::Custom(args.rpc.clone(), args.rpc.replace("http", "ws"));
-        transfer_excess_rewards_with_delegate_tips(
+        transfer_excess_rewards(
             args.payer_file_path,
             cluster,
             &bond_pubkey,

--- a/cli/src/commands/transfer_excess_rewards.rs
+++ b/cli/src/commands/transfer_excess_rewards.rs
@@ -48,6 +48,7 @@ pub async fn handle_transfer_excess_rewards(args: TransferExcessRewardsArgs) -> 
         &bond.stake_account,
         &bond.transient_stake_account,
         target_epoch,
+        current_epoch,
     )
     .await?;
 

--- a/cli/src/commands/transfer_excess_rewards.rs
+++ b/cli/src/commands/transfer_excess_rewards.rs
@@ -8,6 +8,7 @@ use crate::transactions::transfer_excess_rewards_with_delegate_tips;
 use anchor_client::Cluster;
 use anyhow::{anyhow, Result};
 use dialoguer::Confirm;
+use log::info;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_metrics::{datapoint_info, flush};
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
@@ -27,9 +28,8 @@ pub async fn handle_transfer_excess_rewards(args: TransferExcessRewardsArgs) -> 
 
     // Fetch RewardCommissions configured on SoloValidatorBond.
     let bond = fetch_solo_validator_bond(&client, &bond_pubkey).await?;
-
     let reward_commissions = bond.reward_commissions.clone();
-    println!("\nCurrent {:?}", reward_commissions);
+    info!("Current: {:?}", reward_commissions);
 
     // Fetch the current Solana Network epoch.
     let epoch_info = client.get_epoch_info().await?;

--- a/cli/src/commands/validator_bond_manager.rs
+++ b/cli/src/commands/validator_bond_manager.rs
@@ -31,11 +31,7 @@ pub struct ValidatorBondManagerArgs {
     )]
     rpc: String,
     /// The Pye program ID
-    #[arg(
-        short,
-        long,
-        default_value = "PYEQZ2qYHPQapnw8Ms8MSPMNzoq59NHHfNwAtuV26wx"
-    )]
+    #[arg(long, default_value = "PYEQZ2qYHPQapnw8Ms8MSPMNzoq59NHHfNwAtuV26wx")]
     program_id: Pubkey,
     /// Validator's vote accoutn
     #[arg(short, long, env)]

--- a/cli/src/commands/validator_bond_manager.rs
+++ b/cli/src/commands/validator_bond_manager.rs
@@ -21,7 +21,12 @@ use crate::{
 #[derive(Clone, Debug, Parser)]
 pub struct ValidatorBondManagerArgs {
     /// RPC Endpoint
-    #[arg(short, long, env, default_value = "https://api.mainnet-beta.solana.com")]
+    #[arg(
+        short,
+        long,
+        env,
+        default_value = "https://api.mainnet-beta.solana.com"
+    )]
     rpc: String,
     /// The Pye program ID
     #[arg(

--- a/cli/src/commands/validator_bond_manager.rs
+++ b/cli/src/commands/validator_bond_manager.rs
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Clone, Debug, Parser)]
 pub struct ValidatorBondManagerArgs {
     /// RPC Endpoint
-    #[arg(short, long, default_value = "https://api.mainnet-beta.solana.com")]
+    #[arg(short, long, env, default_value = "https://api.mainnet-beta.solana.com")]
     rpc: String,
     /// The Pye program ID
     #[arg(
@@ -31,16 +31,16 @@ pub struct ValidatorBondManagerArgs {
     )]
     program_id: Pubkey,
     /// Validator's vote accoutn
-    #[arg(short, long)]
+    #[arg(short, long, env)]
     vote_pubkey: Pubkey,
     /// Path to payer keypair
-    #[arg(short, long)]
+    #[arg(short, long, env)]
     payer: String,
     /// Maximum RPC requests to send concurrently.
-    #[arg(long, default_value = "50")]
+    #[arg(long, env, default_value = "50")]
     concurrency: usize,
     /// Dry mode to calculate excess rewards without transferring.
-    #[arg(long)]
+    #[arg(long, env)]
     dry_run: bool,
 }
 
@@ -153,6 +153,7 @@ pub async fn handle_validator_bond_manager(args: ValidatorBondManagerArgs) -> Re
 
             // TODO: Make the actual SOL transfer if not a dry run
             if !args.dry_run {
+                // transfer_excess_rewards_with_delegate_tips
                 todo!("Make the actual SOL transfer");
             }
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,7 +23,12 @@ enum Commands {
     /// Transfer excess rewards collected for the last completed epoch to SoloValiatorBond.
     TransferExcessRewards {
         /// RPC Endpoint
-        #[arg(short, long, env, default_value = "https://api.mainnet-beta.solana.com")]
+        #[arg(
+            short,
+            long,
+            env,
+            default_value = "https://api.mainnet-beta.solana.com"
+        )]
         rpc: String,
         /// Path to payer keypair
         #[arg(short, long, env)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,19 +23,19 @@ enum Commands {
     /// Transfer excess rewards collected for the last completed epoch to SoloValiatorBond.
     TransferExcessRewards {
         /// RPC Endpoint
-        #[arg(short, long, default_value = "https://api.mainnet-beta.solana.com")]
+        #[arg(short, long, env, default_value = "https://api.mainnet-beta.solana.com")]
         rpc: String,
         /// Path to payer keypair
-        #[arg(short, long)]
+        #[arg(short, long, env)]
         payer: String,
         /// SoloValidatorBond's pubkey
-        #[arg(short, long)]
+        #[arg(short, long, env)]
         bond: String,
         /// Maximum RPC requests to send concurrently.
-        #[arg(long, default_value = "50")]
+        #[arg(long, env, default_value = "50")]
         concurrency: usize,
         /// Dry mode to calculate excess rewards without transferring.
-        #[arg(long)]
+        #[arg(long, env)]
         dry_run: bool,
     },
 

--- a/cli/src/rewards/block_rewards.rs
+++ b/cli/src/rewards/block_rewards.rs
@@ -1,8 +1,8 @@
 use crate::rpc_utils;
 use anyhow::{anyhow, Result};
+use futures::stream::{self, StreamExt};
 use log::info;
 use pye_core_cpi::pye_core::types::RewardCommissions;
-use futures::stream::{self, StreamExt};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcLeaderScheduleConfig;
 use solana_sdk::commitment_config::CommitmentConfig;

--- a/cli/src/rewards/block_rewards.rs
+++ b/cli/src/rewards/block_rewards.rs
@@ -1,5 +1,6 @@
 use crate::rpc_utils;
 use anyhow::{anyhow, Result};
+use log::info;
 use pye_core_cpi::pye_core::types::RewardCommissions;
 use futures::stream::{self, StreamExt};
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -85,7 +86,7 @@ pub async fn calculate_block_rewards(
     let slot_history = Arc::new(crate::accounts::fetch_slot_history(rpc).await?);
 
     // TODO: Replace with a batched JSON-RPC call to reduce HTTP overhead.
-    println!(
+    info!(
         "Fetching {} Blocks Produced in Epoch {}",
         slots.len(),
         epoch_info.epoch - 1,
@@ -138,7 +139,7 @@ pub async fn calculate_excess_block_reward(
         calculate_block_rewards(client, vote_pubkey, epoch_info, concurrency).await;
 
     if validator_active_stake == 0 {
-        println!("No excess block reward when validator active stake is 0");
+        info!("No excess block reward when validator active stake is 0");
         return Ok(0);
     }
 
@@ -150,14 +151,14 @@ pub async fn calculate_excess_block_reward(
                 validator_active_stake,
                 reward_commissions.block_rewards_bps,
             );
-            println!(
+            info!(
                 "Total Block Reward: {}, Excess Block Commission: {}\n",
                 amount, excess_block_commission
             );
             Ok(excess_block_commission)
         }
         Err(e) => {
-            println!(
+            info!(
                 "Error fetching block reward: {}. Assuming no block reward earned.\n",
                 e
             );

--- a/cli/src/rewards/inflation_rewards.rs
+++ b/cli/src/rewards/inflation_rewards.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use log::{error, info};
 use pye_core_cpi::pye_core::types::RewardCommissions;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
@@ -48,7 +49,8 @@ async fn get_excess_inflation_reward(
         );
         Ok(excess)
     } else {
-        Err(anyhow!("No inflation rewards found for {}", address))
+        // This is the case for stake accounts that are activating 
+        return Ok(0);
     }
 }
 
@@ -64,12 +66,12 @@ pub async fn calculate_excess_inflation_reward(
             .await
         {
             Ok(amount) => {
-                println!("Excess Stake Account Inflation Commission: {:?}", amount);
+                info!("Excess Stake Account Inflation Commission: {:?}", amount);
                 amount
             }
             Err(e) => {
-                println!("Error for stake account: {}", e);
-                0 // Return 0 for stake account on error
+                error!("Error for stake account: {}", e);
+                0 // Return 0 for stake account on error. 
             }
         };
 
@@ -83,14 +85,14 @@ pub async fn calculate_excess_inflation_reward(
         .await
         {
             Ok(amount) => {
-                println!(
+                info!(
                     "Excess Transient Account Inflation Commission: {:?}\n",
                     amount
                 );
                 amount
             }
             Err(e) => {
-                println!("Error for transient account: {}\n", e);
+                error!("Error for transient account: {}\n", e);
                 0 // Return 0 for transient account on error
             }
         }

--- a/cli/src/rewards/inflation_rewards.rs
+++ b/cli/src/rewards/inflation_rewards.rs
@@ -49,7 +49,7 @@ async fn get_excess_inflation_reward(
         );
         Ok(excess)
     } else {
-        // This is the case for stake accounts that are activating 
+        // This is the case for stake accounts that are activating
         return Ok(0);
     }
 }
@@ -71,7 +71,7 @@ pub async fn calculate_excess_inflation_reward(
             }
             Err(e) => {
                 error!("Error for stake account: {}", e);
-                0 // Return 0 for stake account on error. 
+                0 // Return 0 for stake account on error.
             }
         };
 

--- a/cli/src/rewards/mev_rewards.rs
+++ b/cli/src/rewards/mev_rewards.rs
@@ -69,6 +69,8 @@ pub async fn fetch_and_filter_mev_data(
     filter_mev_data(response, vote_pubkey)
 }
 
+// REVIEW: When does MEV epoch data get uploaded to the API? If operators are waiting for epoch 
+// transition, there could be a race condition for MEV epoch data
 pub async fn fetch_mev_data(target_epoch: u64) -> Result<ValidatorsResponse> {
     let http = Client::new();
 

--- a/cli/src/rewards/mev_rewards.rs
+++ b/cli/src/rewards/mev_rewards.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::{anyhow, Result};
 use pye_core_cpi::pye_core::types::RewardCommissions;
 use reqwest::Client;
@@ -65,11 +67,11 @@ pub async fn fetch_and_filter_mev_data(
     vote_pubkey: &Pubkey,
     target_epoch: u64,
 ) -> Result<ValidatorInfo> {
-    let response = fetch_mev_data(target_epoch).await?;
+    let response = fetch_mev_with_retry(target_epoch, 12, Duration::from_secs(3600)).await?;
     filter_mev_data(response, vote_pubkey)
 }
 
-// REVIEW: When does MEV epoch data get uploaded to the API? If operators are waiting for epoch 
+// REVIEW: When does MEV epoch data get uploaded to the API? If operators are waiting for epoch
 // transition, there could be a race condition for MEV epoch data
 pub async fn fetch_mev_data(target_epoch: u64) -> Result<ValidatorsResponse> {
     let http = Client::new();
@@ -85,6 +87,27 @@ pub async fn fetch_mev_data(target_epoch: u64) -> Result<ValidatorsResponse> {
         .json::<ValidatorsResponse>()
         .await
         .map_err(|e| anyhow!("Failed to deserialize response: {}", e))
+}
+
+pub async fn fetch_mev_with_retry(
+    target_epoch: u64,
+    max_attempts: u64,
+    duration: Duration,
+) -> Result<ValidatorsResponse> {
+    let mut attempt: u64 = 0;
+    loop {
+        match fetch_mev_data(target_epoch).await {
+            Ok(res) => return Ok(res),
+            Err(err) => {
+                attempt += 1;
+                if attempt >= max_attempts {
+                    return Err(err);
+                } else {
+                    tokio::time::sleep(duration).await;
+                }
+            }
+        }
+    }
 }
 
 fn filter_mev_data(response: ValidatorsResponse, vote_pubkey: &Pubkey) -> Result<ValidatorInfo> {

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,8 +1,8 @@
 use anchor_client::solana_sdk::instruction::AccountMeta;
 use anchor_client::{Client, Cluster};
 use anyhow::{anyhow, Result};
-use pye_core_cpi::pye_core::client::accounts::SoloValidatorDelegateTips;
 use pye_core_cpi::pye_core::accounts::SoloValidatorBond;
+use pye_core_cpi::pye_core::client::accounts::SoloValidatorDelegateTips;
 use pye_core_cpi::pye_core::ID as PYE_BONDS_ID;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::keypair::read_keypair_file;

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -39,6 +39,8 @@ pub async fn transfer_excess_rewards_with_delegate_tips(
     let client =
         Client::new_with_options(cluster, Arc::clone(&payer), CommitmentConfig::processed());
 
+    // TODO: check balance and send notification if not enough balance
+
     let program = client.program(PYE_BONDS_ID)?;
     let (recent_blockhash, _last_valid_block_height) = program
         .rpc()

--- a/cli/src/transactions.rs
+++ b/cli/src/transactions.rs
@@ -1,25 +1,20 @@
-use anchor_client::solana_sdk::instruction::AccountMeta;
 use anchor_client::{Client, Cluster};
 use anyhow::{anyhow, Result};
 use pye_core_cpi::pye_core::accounts::SoloValidatorBond;
-use pye_core_cpi::pye_core::client::accounts::SoloValidatorDelegateTips;
 use pye_core_cpi::pye_core::ID as PYE_BONDS_ID;
-use solana_sdk::signature::Keypair;
+use solana_sdk::message::Message;
 use solana_sdk::signer::keypair::read_keypair_file;
 use solana_sdk::signer::Signer;
-use solana_sdk::stake;
 use solana_sdk::system_instruction::transfer;
-use solana_sdk::system_program;
-use solana_sdk::sysvar;
 use solana_sdk::transaction::Transaction;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
 use std::sync::Arc;
 
-pub async fn transfer_excess_rewards_with_delegate_tips(
+pub async fn transfer_excess_rewards(
     payer_file_path: String,
     cluster: Cluster,
     bond_pubkey: &Pubkey,
-    bond: &SoloValidatorBond,
+    _bond: &SoloValidatorBond,
     excess_rewards: u64,
 ) -> Result<()> {
     if excess_rewards == 0 {
@@ -48,61 +43,15 @@ pub async fn transfer_excess_rewards_with_delegate_tips(
         .await
         .map_err(|e| anyhow!("Failed to fetch latest blockhash: {}", e))?;
 
-    let mut signing_keypairs = vec![&*payer];
     let mut transfer_ixs = vec![];
 
-    // Generate a new transient stake account keypair it doesn't exist.
-    let mut transient_pubkey = bond.transient_stake_account;
-    let mut transient_is_signer = false;
-
-    let new_transient_keypair = Keypair::new();
-    if transient_pubkey.eq(&Pubkey::default()) {
-        transient_pubkey = new_transient_keypair.pubkey();
-        signing_keypairs.push(&new_transient_keypair);
-        transient_is_signer = true;
-    }
-
-    let (global_settings, _) =
-        Pubkey::find_program_address(&["global_settings".as_bytes()], &program.id());
-
     // Transfer excess rewards from payer to stake account.
-    let transfer_ix = transfer(&payer_pubkey, &bond.stake_account, excess_rewards);
+    let transfer_ix = transfer(&payer_pubkey, bond_pubkey, excess_rewards);
     transfer_ixs.push(transfer_ix);
 
-    // Initiate delegation of excess rewards in stake account.
-    let delegate_ixs = program
-        .request()
-        .accounts(SoloValidatorDelegateTips {
-            bond: *bond_pubkey,
-            validator_vote_account: bond.validator_vote_account,
-            stake_account: bond.stake_account,
-            global_settings,
-            clock: sysvar::clock::ID,
-            stake_program: stake::program::ID,
-            stake_history: sysvar::stake_history::ID,
-            stake_config: stake::config::ID,
-            rent: sysvar::rent::ID,
-            system_program: system_program::ID,
-        })
-        .accounts(vec![
-            AccountMeta::new(transient_pubkey, transient_is_signer),
-            AccountMeta::new_readonly(PYE_BONDS_ID, false),
-        ])
-        .args(pye_core_cpi::pye_core::client::args::SoloValidatorDelegateTips {})
-        .instructions()
-        .map_err(|e| {
-            anyhow!(
-                "Failed to create SoloValidatorDelegateTips instructions: {}",
-                e
-            )
-        })?;
+    let message = Message::new(&[transfer_ixs].concat(), Some(&payer_pubkey));
 
-    let tx = Transaction::new_signed_with_payer(
-        &[transfer_ixs, delegate_ixs].concat(),
-        Some(&payer_pubkey),
-        &signing_keypairs,
-        recent_blockhash,
-    );
+    let tx = Transaction::new(&[payer], message, recent_blockhash);
     let sig = program
         .rpc()
         .send_and_confirm_transaction_with_spinner(&tx)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3"
+services:
+  influxdb:
+    image: influxdb:1.8
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=metrics
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=admin
+    volumes:
+      - influxdb:/var/lib/influxdb
+
+  grafana:
+    image: grafana/grafana:8.5.0
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana:/var/lib/grafana
+
+volumes:
+  influxdb:
+  grafana:

--- a/lib/idls/pye_core.json
+++ b/lib/idls/pye_core.json
@@ -1,5 +1,5 @@
 {
-  "address": "PYEJEeRZLiLjVuBXnGqWgsPJzCazshbmiCk5oQ2CMQe",
+  "address": "PYEQZ2qYHPQapnw8Ms8MSPMNzoq59NHHfNwAtuV26wx",
   "metadata": {
     "name": "bonds",
     "version": "0.2.1",


### PR DESCRIPTION
* fix: Update IDL to unblock transfer
* fix: remove delegate tips instruction because it was failing due to minimum delegation requirements
* fix: adjust active stake calculation because the current method using StakeHistory doesn't actually get a StakeAccount's active stake for the target epoch. Now we are deducting the previous epochs inflation rewards from the currently active stake to get the previous epoch's active stake
* update logging