### PR TITLE
fix: short circuit if excess rewards is negative

### DIFF
--- a/cli/src/commands/transfer_excess_rewards.rs
+++ b/cli/src/commands/transfer_excess_rewards.rs
@@ -99,7 +99,7 @@ pub async fn handle_transfer_excess_rewards(args: TransferExcessRewardsArgs) -> 
     flush();
 
     if excess_rewards <= 0 {
-        println!(
+        info!(
             "No excess rewards to transfer to SoloValidatorBond for epoch {}\n",
             target_epoch
         );
@@ -107,7 +107,7 @@ pub async fn handle_transfer_excess_rewards(args: TransferExcessRewardsArgs) -> 
     }
 
     if args.dry_run {
-        println!("Dry run complete");
+        info!("Dry run complete");
         return Ok(());
     }
 
@@ -129,7 +129,7 @@ pub async fn handle_transfer_excess_rewards(args: TransferExcessRewardsArgs) -> 
         .await
         .map_err(|e| anyhow!("Failed to transfer excess rewards: {}", e))
     } else {
-        println!("Aborted: user declined to transfer excess rewards.");
+        info!("Aborted: user declined to transfer excess rewards.");
         Ok(())
     }
 }

--- a/cli/src/commands/validator_bond_manager.rs
+++ b/cli/src/commands/validator_bond_manager.rs
@@ -180,9 +180,10 @@ pub async fn handle_validator_bond_manager(args: ValidatorBondManagerArgs) -> Re
 
             let excess_rewards =
                 excess_inflation_reward + excess_block_commission + excess_mev_commission;
+            
             info!(
                 "Bond: {}\nSOL to transfer: {}\n\n",
-                excess_rewards, excess_rewards
+                bond_pubkey, excess_rewards
             );
 
             datapoint_info!(
@@ -197,7 +198,15 @@ pub async fn handle_validator_bond_manager(args: ValidatorBondManagerArgs) -> Re
                 ("total_excess_rewards", excess_rewards, i64),
             );
 
-            // Make the actual SOL transfer if not a dry run
+            if excess_rewards <= 0 {
+                info!(
+                    "No excess rewards to transfer to bond {} for epoch {}\n",
+                    bond_pubkey, target_epoch
+                );
+                continue;
+            }
+
+            // Make the actual SOL transfer if not a dry run and rewards are greater than 0
             if !args.dry_run {
                 // transfer_excess_rewards_with_delegate_tips
                 let cluster = Cluster::Custom(args.rpc.clone(), args.rpc.replace("http", "ws"));


### PR DESCRIPTION
### Context
Validators may want to create unique structures that allows stakers to take an opinion on the different buckets of rewards. E.g. validator takes 100% commission on inflation and MEV rewards but 0% commission on block rewards. These types of cases can result in negative balances when the validator's public staking commission structure results in higher yields. 

In this case, the CLI shouldn't take any action. 
### Issue
Currently the validator bond manager command fails due to a negative transfer attempt.

### Solution
We short circuit prior to transfer if _excess_rewards_ is negative.  