### PR TITLE
feat: log epoch boundary checks

### DIFF
--- a/cli/src/commands/validator_bond_manager.rs
+++ b/cli/src/commands/validator_bond_manager.rs
@@ -45,7 +45,7 @@ pub struct ValidatorBondManagerArgs {
     #[arg(short, long, env)]
     vote_pubkey: Pubkey,
     /// Restricts bond payments to only bonds issued by pubkeys in this list.
-    #[arg(short, long, env, value_delimiter=',')]
+    #[arg(short, long, env, value_delimiter = ',')]
     issuers: Vec<Pubkey>,
     /// Path to payer keypair
     #[arg(short, long, env)]

--- a/cli/src/rpc_utils.rs
+++ b/cli/src/rpc_utils.rs
@@ -105,6 +105,11 @@ pub async fn wait_for_next_epoch(
 ) -> EpochInfo {
     loop {
         tokio::time::sleep(Duration::from_secs(cycle_secs)).await;
+        info!(
+            "Checking for epoch boundary... current_epoch: {}",
+            current_epoch
+        );
+
         let new_epoch_info = match rpc_client.get_epoch_info().await {
             Ok(info) => info,
             Err(e) => {


### PR DESCRIPTION
Some users want to see that the CLI is still running, so it now logs every time it's checking for an epoch boundary